### PR TITLE
Another fix to the regex for phone numbers

### DIFF
--- a/backend/Fakebook/Fakebook.Domain/Utility/RegularExpressions.cs
+++ b/backend/Fakebook/Fakebook.Domain/Utility/RegularExpressions.cs
@@ -5,6 +5,6 @@
         public const string NoSpecialCharacters = @"^[A-Za-z0-9 '-,.#?:]*$";
         public const string NameCharacters = @"^[A-Za-z0-9 -]*$";
         public const string EmailCharacters = @"^[a-zA-Z]+[a-zA-Z0-9\.]*[a-zA-Z0-9]*\@[a-zA-Z]+[a-zA-Z0-9]*\.([a-zA-Z]+){0,253}$";
-        public const string PhoneNumberCharacters = @"^(\([0-9]{3}\) |[0-9]{3}[ -]?)?[0-9]{3}[ -]?[0-9]{4}$";
+        public const string PhoneNumberCharacters = @"^(\([0-9]{3}\)|[0-9]{3})?[ -]?[0-9]{3}[ -]?[0-9]{4}$";
     }
 }


### PR DESCRIPTION
Added moved around a few characters to allow the phone number regex to be slightly more lenient, specifically a hyphen or space between parentheses and the second set of number triplets.