### PR TITLE
[Fix] Remove a post that has likes on it.

### DIFF
--- a/backend/Fakebook/Fakebook.Domain/Repository/PostRepo.cs
+++ b/backend/Fakebook/Fakebook.Domain/Repository/PostRepo.cs
@@ -145,8 +145,13 @@ namespace Fakebook.Domain.Repository
                     .Where(c => c.PostId == entity.Id)
                     .ToListAsync();
 
-                _context.PostEntities.Remove(entity);
+                var likes = await _context.LikeEntities
+                    .Where(l => l.PostId == entity.Id)
+                    .ToListAsync();
+
                 _context.CommentEntities.RemoveRange(comments);
+                _context.LikeEntities.RemoveRange(likes);
+                _context.PostEntities.Remove(entity);
 
                 await _context.SaveChangesAsync();
                 return true;


### PR DESCRIPTION
Before, a post that had likes on it could not be removed. This is a fix to allow for the post to be removed when it has likes.